### PR TITLE
Fix issue where donation_exists() throws an error due to NULL value

### DIFF
--- a/woocommerce-quick-donation.php
+++ b/woocommerce-quick-donation.php
@@ -216,7 +216,7 @@ class wc_quick_donation{
 	 */
 	public function donation_exsits(){
 		global $woocommerce; 
-		if( sizeof($woocommerce->cart->get_cart()) > 0){
+		if(is_object($woocommerce->cart) && sizeof($woocommerce->cart->get_cart()) > 0){
 			foreach($woocommerce->cart->get_cart() as $cart_item_key => $values){
 				$_product = $values['data'];
 				if($_product->id == $this->donation_id){


### PR DESCRIPTION
Fix issue where donation_exists() throws an error due to NULL value when viewing donations in admin area.